### PR TITLE
Schema 2.2.0

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -480,6 +480,16 @@
               true
             ]
           },
+          "greyscale": {
+            "$id": "#/properties/layers/items/properties/greyscale",
+            "type": "boolean",
+            "title": "Greyscale rendering",
+            "description": "Use to render the layer in greyscale on client",
+            "default": false,
+            "examples": [
+              true
+            ]
+          },
           "displayInLayerSwitcher": {
             "$id": "#/properties/layers/items/properties/displayInLayerSwitcher",
             "type": "boolean",

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
   "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/hslayers/map-compositions/2.1.0/schema.json",
+  "$id": "https://raw.githubusercontent.com/hslayers/map-compositions/2.2.0/schema.json",
   "type": "object",
   "title": "Schema of map compositions supported in Hslayers-ng",
   "required": [
@@ -525,6 +525,7 @@
                 "enum": [
                   "ol.format.KML",
                   "ol.format.GeoJSON",
+                  "ol.format.GPX",
                   "hs.format.WFS",
                   "hs.format.externalWFS",
                   "hs.format.Sparql"


### PR DESCRIPTION
* introduce new `greyscale` flag for client rendering of the layer in greys
* add support for GPX vector format

Closes #6
Closes #8 